### PR TITLE
Added support for setting Tado AC controls

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -245,7 +245,7 @@ class Tado:
         data = self._apiCall(cmd, "DELETE", {}, True)
         return data
 
-    def setZoneOverlay(self, zone, overlayMode, setTemp=None, duration=None):
+    def setZoneOverlay(self, zone, overlayMode, setTemp=None, duration=None, zoneType="HEATING", acMode=None):
         """set current overlay for a zone"""
         # pylint: disable=C0103
 
@@ -258,13 +258,22 @@ class Tado:
 
         if setTemp is None:
             post_data["setting"] = {
-                "type":"HEATING",
+                "type":zoneType,
                 "power":"OFF"
+            }
+        elif acMode is None:
+            post_data["setting"] = {
+                "type":zoneType,
+                "power":"ON",
+                "temperature":{
+                    "celsius": setTemp
+                }
             }
         else:
             post_data["setting"] = {
-                "type":"HEATING",
+                "type":zoneType,
                 "power":"ON",
+                "mode":acMode,
                 "temperature":{
                     "celsius": setTemp
                 }


### PR DESCRIPTION
Add support for controlling Tado AIR_CONDITIONING unit by amending the function to include two additional parameters.
![sending controls to tado for ac](https://user-images.githubusercontent.com/6518915/47312060-3a9f6180-d633-11e8-9e61-f5fd621ff648.png)

Ensure backwards compatible with default zoneType as "HEATING"