### PR TITLE
Add support to get/set a schedule for a zone

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Author: Chris Jewell <chrism0dwk@gmail.com>
 Modified: Gareth Jeanne <contact@garethjeanne.co.uk>
           Wolfgang Malgadey <w.malgadey@gmail.com>
+          Matt Clayton <matt.r.clayton@gmail.com>

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -213,6 +213,28 @@ class Tado:
         return {'temperature' : data['insideTemperature']['celsius'],
                 'humidity'    : data['humidity']['percentage']}
 
+    def getSchedule(self, zone, day=None):
+        """Get the JSON representation of the schedule for a zone"""
+        # pylint: disable=C0103
+
+        if day:
+            cmd = 'zones/%i/schedule/timetables/1/blocks/%s' % (zone,day)
+        else:
+            cmd = 'zones/%i/schedule/timetables/1/blocks' % zone
+
+        data = self._apiCall(cmd, "GET", {}, True)
+        return data
+
+    def setSchedule(self, zone, day, data):
+        """Set the schedule for a zone, day is required"""
+        # pylint: disable=C0103
+
+        cmd = 'zones/%i/schedule/timetables/1/blocks/%s' % (zone,day)
+
+        data = self._apiCall(cmd, "PUT", data, True)
+        return data
+
+
     def getWeather(self):
         """Gets outside weather data"""
         # pylint: disable=C0103

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -9,6 +9,7 @@ import urllib.request
 import urllib.parse
 import urllib.error
 
+from enum import IntEnum
 from http.cookiejar import CookieJar
 
 
@@ -20,6 +21,12 @@ class Tado:
     Example usage: t = Tado('me@somewhere.com', 'mypasswd')
                    t.getClimate(1) # Get climate, zone 1.
     """
+
+    """Constants needed for get/set Schedule and Timetable"""
+    class Timetable(IntEnum):
+        ONE_DAY = 0
+        THREE_DAY = 1
+        SEVEN_DAY = 2
 
     _debugCalls = False
 
@@ -213,27 +220,66 @@ class Tado:
         return {'temperature' : data['insideTemperature']['celsius'],
                 'humidity'    : data['humidity']['percentage']}
 
-    def getSchedule(self, zone, day=None):
-        """Get the JSON representation of the schedule for a zone"""
+    def getTimetable(self, zone):
+        """Get the Timetable type currently active"""
         # pylint: disable=C0103
 
+        cmd = 'zones/%i/schedule/activeTimetable' % (zone)
+
+        data = self._apiCall(cmd, "GET", {}, True)
+
+        if "id" in data:
+            return Tado.Timetable(data["id"])
+
+        raise Exception('Returned data did not contain "id" : '+str(data))
+
+    def setTimetable(self, zone, id):
+        """Set the Timetable type currently active
+           id = 0 : ONE_DAY (MONDAY_TO_SUNDAY)
+           id = 1 : THREE_DAY (MONDAY_TO_FRIDAY, SATURDAY, SUNDAY)
+           id = 3 : SEVEN_DAY (MONDAY, TUESDAY, WEDNESDAY ...)"""
+        # pylint: disable=C0103
+
+        # Type checking
+        if not isinstance(id, Tado.Timetable):
+            raise TypeError('id must be an instance of Tado.Timetable')
+
+        cmd = 'zones/%i/schedule/activeTimetable' % (zone)
+
+        data = self._apiCall(cmd, "PUT", {'id': id }, True)
+        return data
+
+    def getSchedule(self, zone, id, day=None):
+        """Get the JSON representation of the schedule for a zone
+           a Zone has 3 different schedules, one for each timetable
+           (see setTimetable) """
+        # pylint: disable=C0103
+
+        # Type checking
+        if not isinstance(id, Tado.Timetable):
+            raise TypeError('id must be an instance of Tado.Timetable')
+
         if day:
-            cmd = 'zones/%i/schedule/timetables/1/blocks/%s' % (zone,day)
+            cmd = 'zones/%i/schedule/timetables/%i/blocks/%s' % (zone,id,day)
         else:
-            cmd = 'zones/%i/schedule/timetables/1/blocks' % zone
+            cmd = 'zones/%i/schedule/timetables/%i/blocks' % (zone,id)
 
         data = self._apiCall(cmd, "GET", {}, True)
         return data
 
-    def setSchedule(self, zone, day, data):
+
+    def setSchedule(self, zone, id, day, data):
         """Set the schedule for a zone, day is required"""
         # pylint: disable=C0103
 
-        cmd = 'zones/%i/schedule/timetables/1/blocks/%s' % (zone,day)
+        # Type checking
+        if not isinstance(id, Tado.Timetable):
+            raise TypeError('id must be an instance of Tado.Timetable')
+
+        cmd = 'zones/%i/schedule/timetables/%i/blocks/%s' % (zone,id,day)
 
         data = self._apiCall(cmd, "PUT", data, True)
         return data
-
 
     def getWeather(self):
         """Gets outside weather data"""


### PR DESCRIPTION
Add API to get/set a schedule for a zone.
Possible Usecases:
- Programatically update a zone to different schedules (Summer/Winter, Guest Room with/without guest)
- Clone schedules across all zones - so multiple rooms can share the same schedule without having to enter them manually in the Tado app.

Example Usage:
```
from PyTado.PyTado.interface import Tado

t = Tado('user','pass')

## Set Tado in zone 5 to use the THREE_DAY timetable
t.setTimetable(5,Tado.Timetable.THREE_DAY)

## Get the schedule for zone 5,  MONDAY_TO_FRIDAY in the THREE_DAY timetable.
schedule = t.getSchedule(5,Tado.Timetable.THREE_DAY,"MONDAY_TO_FRIDAY")

## Somehow modify the current schedule, i am just setting all temps to 19
for item in schedule:
    item['setting']['temperature']['celsius'] = 19 
    del(item['setting']['temperature']['fahrenheit']) # Just because It would be wrong otherwise

## Tell Tado to apply the new schedule to the "Monday to Friday" day in the THREE_DAY timetable
newSchedule = t.setSchedule(5, Tado.Timetable.THREE_DAY, "MONDAY_TO_FRIDAY", schedule)

## Print out the returned data from the Tado API, which should be the new schedule
print(newSchedule)
```
